### PR TITLE
Overwrite discovery default profile to set if.names=0

### DIFF
--- a/pxe/PXEGrub2_global_default.erb
+++ b/pxe/PXEGrub2_global_default.erb
@@ -7,7 +7,7 @@ name: PXEGrub2 global default
 set default=0
 set timeout=20
 
-<%= snippet "pxegrub2_discovery" %>
+<%= snippet "RG pxegrub2_discovery" %>
 
 <%= snippet "pxegrub2_chainload" %>
 

--- a/pxe/PXEGrub_global_default.erb
+++ b/pxe/PXEGrub_global_default.erb
@@ -7,7 +7,7 @@ name: PXEGrub global default
 default=0
 timeout=20
 
-<%= snippet "pxegrub_discovery" %>
+<%= snippet "RG pxegrub_discovery" %>
 
 <%= snippet "pxegrub_chainload" %>
 

--- a/pxe/PXELinux_global_default.erb
+++ b/pxe/PXELinux_global_default.erb
@@ -11,9 +11,9 @@ TIMEOUT 200
 TOTALTIMEOUT 6000
 ONTIMEOUT discovery
 
-<%= snippet "pxelinux_chainload" %>
+<%= snippet "RG pxelinux_discovery" %>
 
-<%= snippet "pxelinux_discovery" %>
+<%= snippet "pxelinux_chainload" %>
 
 <%= snippet "RG pxelinux_rescue" %>
 

--- a/snippets/pxegrub2_discovery.erb
+++ b/snippets/pxegrub2_discovery.erb
@@ -1,0 +1,13 @@
+<%#
+kind: snippet
+name: pxegrub2_discovery
+-%>
+<%#
+discovery image is based on CentOS/RHEL and therefor it is affected by https://bugzilla.redhat.com/show_bug.cgi?id=1259015.
+In short, before RHEL 7.2 virtio driver didn't have the new persistent naming scheme, causing interfaces to be named eth0, eth1, etc..
+If you want to enable the new persistent naming scheme and get inteface names like ens3, add net.ifnames=1 to the linuxefi line below.
+-%>
+menuentry 'Foreman Discovery Image' {
+  linuxefi boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force net.ifnames=0 rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
+  initrdefi boot/fdi-image/initrd0.img
+}

--- a/snippets/pxegrub_discovery.erb
+++ b/snippets/pxegrub_discovery.erb
@@ -1,0 +1,13 @@
+<%#
+kind: snippet
+name: pxegrub_discovery
+-%>
+<%#
+discovery image is based on CentOS/RHEL and therefor it is affected by https://bugzilla.redhat.com/show_bug.cgi?id=1259015.
+In short, before RHEL 7.2 virtio driver didn't have the new persistent naming scheme, causing interfaces to be named eth0, eth1, etc..
+If you want to enable the new persistent naming scheme and get inteface names like ens3, add net.ifnames=1 to the kernel line below.
+-%>
+# http://projects.theforeman.org/issues/15997
+title Foreman Discovery Image - not supported with Grub 1.x
+  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force net.ifnames=0 rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-$net_default_mac
+  initrd boot/fdi-image/initrd0.img

--- a/snippets/pxelinux_discovery.erb
+++ b/snippets/pxelinux_discovery.erb
@@ -1,0 +1,14 @@
+<%#
+kind: snippet
+name: pxelinux_discovery
+-%>
+<%#
+discovery image is based on CentOS/RHEL and therefor it is affected by https://bugzilla.redhat.com/show_bug.cgi?id=1259015.
+In short, before RHEL 7.2 virtio driver didn't have the new persistent naming scheme, causing interfaces to be named eth0, eth1, etc..
+If you want to enable the new persistent naming scheme and get inteface names like ens3, add net.ifnames=1 to the APPEND line below.
+-%>
+LABEL discovery
+  MENU LABEL Foreman Discovery Image
+  KERNEL boot/fdi-image/vmlinuz0
+  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force net.ifnames=0 rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset proxy.url=<%= foreman_server_url %> proxy.type=foreman
+  IPAPPEND 2


### PR DESCRIPTION
Copy from default discovery boot options, but netnames is disabled, so it names interfaces ethX 