### PR TITLE
burn-in off on VMs and provision interface form built in variable

### DIFF
--- a/preseed/PXELinux.erb
+++ b/preseed/PXELinux.erb
@@ -19,7 +19,7 @@ oses:
   if @host.params['blacklist']
     options << @host.params['blacklist'].split(',').collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
   end
-  netcfg_choose_interface = (@host.params['provision_interface'] and not @host.params['provision_interface'].empty?)? "#{@host.params['provision_interface']}" : 'auto'
+  netcfg_choose_interface = (@host.provision_interface.identifier and not @host.provision_interface.identifier.empty?) ? @host.provision_interface.identifier : 'auto'
   options << "interface=#{netcfg_choose_interface}"
   options << "hostname=#{@host.name}"
   if @host.operatingsystem.name == 'Debian'

--- a/preseed/finish.erb
+++ b/preseed/finish.erb
@@ -11,7 +11,8 @@ oses:
   puppet_enabled = pm_set || @host.params['force-puppet'] && @host.params['force-puppet'] == 'true'
   salt_enabled = @host.params['salt_master'] ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
-  burnin_enabled = @host.params['burn-in'] ? false : true
+  is_physical = (@host.facts['virtual'] == 'physical') ? true : false
+  burnin_enabled = @host.params['burn-in'] and @host.params['burn-in'].bol ? @host.params['burn-in'] : is_physical
   packages_host = @host.params['packages_host'] ? @host.params['packages_host'] : "packages.#{@host.domain}"
 %>
 

--- a/preseed/provision.erb
+++ b/preseed/provision.erb
@@ -12,7 +12,7 @@ oses:
   puppet_enabled = false if @host.param_true?('disable-puppet')
   proxy_string = @host.params['http-proxy'] ? " http://#{@host.params['http-proxy']}:#{@host.params['http-proxy-port']}" : ''
   aptly_host = (@host.params['aptly_host'] and not @host.params['aptly_host'].empty?) ? @host.params['aptly_host'] : "aptly.#{@host.domain}"
-  netcfg_choose_interface = (@host.params['provision_interface'] and not @host.params['provision_interface'].empty?)? "#{@host.params['provision_interface']}" : 'auto'
+  netcfg_choose_interface = (@host.provision_interface.identifier and not @host.provision_interface.identifier.empty?) ? @host.provision_interface.identifier : 'auto'
 
   preseed_extra_packages = (@host.params['extra_packages'] and not @host.params['extra_packages'].empty?) ? @host.params['extra_packages'].split(',') : []
   preseed_extra_packages << "lsb-release"


### PR DESCRIPTION
burn is enabled only on physical nodes by default, but can be overwritten via parameter

get provision interface from built in parameter