### PR TITLE
by default use chainload to fix multiple network PXE stuck issue

### DIFF
--- a/pxe/PXELinux_default_local_boot.erb
+++ b/pxe/PXELinux_default_local_boot.erb
@@ -9,7 +9,7 @@ PROMPT 0
 MENU TITLE PXE Menu
 TIMEOUT 200
 TOTALTIMEOUT 6000
-ONTIMEOUT local
+ONTIMEOUT local_chain_hd0
 
 <%= snippet "pxelinux_chainload" %>
 

--- a/snippets/pxelinux_chainload.erb
+++ b/snippets/pxelinux_chainload.erb
@@ -2,6 +2,11 @@
 kind: snippet
 name: pxelinux_chainload
 %>
+LABEL local_chain_hd0
+  MENU LABEL Chainload the first hard drive (hd0)
+  COM32 chain.c32
+  APPEND hd0
+
 LABEL local
   MENU LABEL Local boot
   LOCALBOOT 0
@@ -13,11 +18,6 @@ LABEL local_primary
 LABEL local_skip
   MENU LABEL Boot from the next BIOS device
   LOCALBOOT -1
-
-LABEL local_chain_hd0
-  MENU LABEL Chainload the first hard drive (hd0)
-  COM32 chain.c32
-  APPEND hd0
 
 LABEL local_chain_hd1
   MENU LABEL Chainload the second hard drive (hd1)


### PR DESCRIPTION
PXE menu doesn't exit if multiple NICs are enable for PXE (random each boot)